### PR TITLE
Propose Qdrant Indexing Time Experiment

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -290,8 +290,11 @@ def main(query, corpuss, top_k, token_counts) -> pd.DataFrame:
         #                  qdrant                       #
         #################################################
         qdrant_client = QdrantClient(
-            url="<your-qdrant-instance-url-here>",
-            api_key="<your-api-key-here>",
+            ":memory:", # fast, wraps numpy
+
+            # persistent, scalable
+            # url="<your-qdrant-instance-url-here>",
+            # api_key="<your-api-key-here>",
         )
 
         qdrant_client.recreate_collection(


### PR DESCRIPTION
Qdrant has an `:memory:` mode which is faster and I think would be a fairer comparison to in-memory `numpy`