### PR TITLE
Device configuration and support for Python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ a blazing fast, lightweight, and simple vector database written in less than 200
 ```python
 from vlite import VLite
 
-db = VLite()
+db = VLite() # default mps
+
+# db = VLite(device="cpu") # to run on cpu
 
 db.memorize(["hello world"]*5)
 

--- a/vlite/main.py
+++ b/vlite/main.py
@@ -7,10 +7,10 @@ class VLite:
     '''
     vlite is a simple vector database that stores vectors in a numpy array.
     '''
-    def __init__(self, collection='vlite.npz',device='mps'):
+    def __init__(self, collection='vlite.npz',device='mps',model_name=None):
         self.collection = collection
         self.device = device
-        self.model = EmbeddingModel()
+        self.model = EmbeddingModel() if model_name is None else EmbeddingModel(model_name)
         try:
             with np.load(self.collection, allow_pickle=True) as data:
                 self.texts = data['texts'].tolist()

--- a/vlite/main.py
+++ b/vlite/main.py
@@ -7,8 +7,9 @@ class VLite:
     '''
     vlite is a simple vector database that stores vectors in a numpy array.
     '''
-    def __init__(self, collection='vlite.npz'):
+    def __init__(self, collection='vlite.npz',device='mps'):
         self.collection = collection
+        self.device = device
         self.model = EmbeddingModel()
         try:
             with np.load(self.collection, allow_pickle=True) as data:
@@ -35,7 +36,7 @@ class VLite:
     def memorize(self, text, id=None, metadata=None):
         id = id or str(uuid4())
         chunks = chop_and_chunk(text)
-        encoded_data = self.model.embed(texts=chunks, device="mps")
+        encoded_data = self.model.embed(texts=chunks, device=self.device)
         self.vectors = np.vstack((self.vectors, encoded_data))
         for chunk in chunks:
             self.texts.append(chunk)
@@ -50,7 +51,7 @@ class VLite:
             return self.metadata[id]
         if text:
 
-            sims = cos_sim(self.model.embed(texts=text, device="cpu") , self.vectors)
+            sims = cos_sim(self.model.embed(texts=text, device=self.device) , self.vectors)
             print("[remember] Sims:", sims.shape)
             sims = sims[0]
 

--- a/vlite/utils.py
+++ b/vlite/utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import pysbd
 import PyPDF2
 import itertools
+from typing import List
 from transformers import AutoTokenizer, AutoModel
 import regex as re
 
@@ -79,7 +80,7 @@ def load_file(pdf_path):
             extracted_text.append(page.extract_text())  
     return extracted_text
 
-def visualize_tokens(token_values: list[str]) -> None:
+def visualize_tokens(token_values: List[str]) -> None:
         backgrounds = itertools.cycle(
             ["\u001b[48;5;{}m".format(i) for i in [167, 179, 185, 77, 80, 68, 134]]
         )


### PR DESCRIPTION
VLite constructor takes device configuration to use in memorize and remember.
List typing used to make it work with < Python 3.9