### PR TITLE
feat: updated chop_and_chunk for better text chunking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.6.2
 numpy==1.23.2
 pandas==1.4.4
 pinecone_client==2.0.13
-PyPDF2==2.10.4
+#PyPDF2==2.10.4
 PyPDF2==3.0.1
 pysbd==0.3.4
 qdrant_client==1.3.1
@@ -13,3 +13,4 @@ setuptools==65.3.0
 torch==1.13.1
 tqdm==4.64.1
 transformers==4.25.1
+langchain

--- a/vlite/utils.py
+++ b/vlite/utils.py
@@ -1,9 +1,10 @@
-import numpy as np
-import pysbd
-import PyPDF2
 import itertools
-from transformers import AutoTokenizer, AutoModel
-import regex as re
+
+import PyPDF2
+import numpy as np
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from transformers import AutoTokenizer
+
 
 # def chop_and_chunk(text, max_seq_length=256):
 #     if isinstance(text, str):
@@ -30,65 +31,84 @@ import regex as re
 #                     buffer += ""
 #     return chunks
 
-def chop_and_chunk(text, max_seq_length=256):
+# def chop_and_chunk(text, max_seq_length=256):
+#     """
+#     Chop and chunk a text into smaller pieces of text.
+#
+#     Args:
+#     text: string, list of strings, or array of strings
+#     max_seq_length: maximum length of the text
+#     """
+#     if isinstance(text, str):
+#         text = [text]
+#
+#     # If text is already split into chunks by newlines, simply return it
+#     if all('\n' in t for t in text):
+#         return text
+#
+#     chunks = []
+#     for t in text:
+#         # Split by newlines
+#         parts = re.split('\n+', t)
+#
+#         for p in parts:
+#             tokens = p.split()
+#             chunk = ''
+#             count = 0
+#             for t in tokens:
+#                 if count + len(t) < max_seq_length:
+#                     count += len(t)
+#                     chunk += t + ' '
+#                 else:
+#                     chunks.append(chunk.strip())
+#                     count = 0
+#                     chunk = ''
+#             if chunk != '':
+#                 chunks.append(chunk.strip())
+#     return chunks
+
+
+def chop_and_chunk(text, max_seq_length=256, chunk_overlap=0):
     """
-    Chop and chunk a text into smaller pieces of text. 
-    
+    Chop and chunk a text into smaller pieces of text.
+
     Args:
-    text: string, list of strings, or array of strings 
+    text: string, list of strings, or array of strings
     max_seq_length: maximum length of the text
     """
-    if isinstance(text, str):
-        text = [text]
-        
-    # If text is already split into chunks by newlines, simply return it 
-    if all('\n' in t for t in text):
-        return text 
-        
-    chunks = []
-    for t in text: 
-        # Split by newlines 
-        parts = re.split('\n+', t)  
-        
-        for p in parts:
-            tokens = p.split()
-            chunk = ''
-            count = 0
-            for t in tokens:
-                if count + len(t) < max_seq_length:
-                    count += len(t) 
-                    chunk += t + ' '
-                else:
-                    chunks.append(chunk.strip())
-                    count = 0
-                    chunk = ''
-            if chunk != '':
-                chunks.append(chunk.strip())
+    splitter = RecursiveCharacterTextSplitter(chunk_size=max_seq_length,
+                                              separators=['\n\n', '\n', ' ', ''],
+                                              chunk_overlap=chunk_overlap)
+    chunks = splitter.split_text("".join(text))
     return chunks
-    
+
+
 def cos_sim(a, b):
     sims = a @ b.T
-    sims /= np.linalg.norm(a) * np.linalg.norm(b, axis=1) 
+    sims /= np.linalg.norm(a) * np.linalg.norm(b, axis=1)
     return sims
+
 
 def load_file(pdf_path):
     extracted_text = []
     with open(pdf_path, "rb") as file:
         reader = PyPDF2.PdfReader(file)
         for page in iter(reader.pages):
-            extracted_text.append(page.extract_text())  
+            extracted_text.append(page.extract_text())
     return extracted_text
 
+
 def visualize_tokens(token_values: list[str]) -> None:
-        backgrounds = itertools.cycle(
-            ["\u001b[48;5;{}m".format(i) for i in [167, 179, 185, 77, 80, 68, 134]]
-        )
-        interleaved = itertools.chain.from_iterable(zip(backgrounds, token_values))
-        print(("".join(interleaved) + "\u001b[0m"))
+    backgrounds = itertools.cycle(
+        ["\u001b[48;5;{}m".format(i) for i in [167, 179, 185, 77, 80, 68, 134]]
+    )
+    interleaved = itertools.chain.from_iterable(zip(backgrounds, token_values))
+    print(("".join(interleaved) + "\u001b[0m"))
+
 
 def token_count(texts):
-        tz = AutoTokenizer.from_pretrained('sentence-transformers/all-MiniLM-L6-v2', use_fast=True)
-        tokens = 0
-        for text in texts:
-            tokens+=len(tz.tokenize(text, padding=True, truncation=True))
-        return tokens
+    tz = AutoTokenizer.from_pretrained('sentence-transformers/all-MiniLM-L6-v2', use_fast=True)
+    tokens = 0
+    for text in texts:
+        tokens += len(tz.tokenize(text, padding=True, truncation=True))
+    return tokens


### PR DESCRIPTION
*chop_and_chunk* function can be improved both for separators and also for chunk_overlap.
I introduced langchain RecursiveCharacterTextSplitter for a quick upgrade. 

There's also a fix to be made in the requirements, since it points two version of the same library (PyPDF).

Code is tested against **test/test.py**, others will fail because it fails to load some resources that aren't available in the public repo. 

Hope it helps